### PR TITLE
Fix README rendering on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The End!
 
 Which when compiled produces the following document:
 
-<img src="./example.png" width="600" border="1"/>
+<img src="https://github.com/curvenote/jtex/blob/main/example.png?raw=true" width="600" border="1"/>
 
 The document layout is flexible and will be based on structure provided in the `template.tex` file, where the modified jinja syntax (`[-`, `-]`) is used to expand variables from the matching DocModel provided in `data.yml`.
 


### PR DESCRIPTION
Fix a big white box in place of the image rendered on PyPI https://pypi.org/project/jtex/

<img width="797" alt="image" src="https://user-images.githubusercontent.com/8834829/167527628-e8fcb793-0cec-44f6-b07f-59fb311d6218.png">


Follows recommendation from https://stackoverflow.com/questions/41983209/how-do-i-add-images-to-a-pypi-readme-that-works-on-github#comment116597345_46875147